### PR TITLE
Ensure dependant libraries are included

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM docker.io/nvidia/cuda:12.6.2-devel-ubi9
+FROM docker.io/nvidia/cuda:12.4.1-devel-ubi9
 
 LABEL maintainer=afred@redhat.com \
       io.k8s.display-name="Ollama AI" \

--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,4 @@
-#FROM docker.io/nvidia/cuda:12.2.2-runtime-ubi9
-FROM docker.io/nvidia/cuda:12.3.2-devel-ubi9
+FROM docker.io/nvidia/cuda:12.6.2-devel-ubi9
 
 LABEL maintainer=afred@redhat.com \
       io.k8s.display-name="Ollama AI" \

--- a/Containerfile.build
+++ b/Containerfile.build
@@ -1,4 +1,4 @@
-FROM docker.io/nvidia/cuda:12.3.2-devel-ubi9
+FROM docker.io/nvidia/cuda:12.4.1-devel-ubi9
 
 ARG VERSION
 ARG GOLANG_VERSION=1.22.1
@@ -21,13 +21,14 @@ RUN go generate ./... \
     && go build . \
     && ls -l /ollama
 
-FROM docker.io/nvidia/cuda:12.6.2-runtime-ubi9
+FROM docker.io/nvidia/cuda:12.4.1-runtime-ubi9
 
 RUN dnf -y update \
     && dnf install -y --nodocs pciutils \
     && dnf clean all && rm -rf /var/cache/*
 
 COPY --from=0 /ollama/ollama /usr/local/bin/ollama
+COPY --from=0 /ollama/dist/linux-amd64/lib/ollama /usr/lib/ollama
 
 LABEL maintainer=afred@redhat.com \
       io.k8s.display-name="Ollama AI" \

--- a/Containerfile.build
+++ b/Containerfile.build
@@ -21,7 +21,7 @@ RUN go generate ./... \
     && go build . \
     && ls -l /ollama
 
-FROM docker.io/nvidia/cuda:12.3.2-runtime-ubi9
+FROM docker.io/nvidia/cuda:12.6.2-runtime-ubi9
 
 RUN dnf -y update \
     && dnf install -y --nodocs pciutils \


### PR DESCRIPTION
After upgrading Ollama to `v0.4.7` the deployment would error out with the following message:
```
libggml_cuda_v12.so: cannot open shared object file: No such file or directory
```

After `0.4.x`, when building the Ollama container image, we need to ensure we're including the libraries that are generated during the build as well.