### PR TITLE
Upgrade ollama to v0.5.5

### DIFF
--- a/Containerfile.build
+++ b/Containerfile.build
@@ -1,4 +1,4 @@
-FROM docker.io/nvidia/cuda:12.4.1-devel-ubi9
+FROM docker.io/nvidia/cuda:12.6.3-devel-ubi9
 
 ARG VERSION
 ARG GOLANG_VERSION=1.22.1
@@ -17,11 +17,10 @@ RUN dnf clean all && rm -rf /var/cache/* \
 #USER root
 WORKDIR /ollama
 
-RUN go generate ./... \
-    && go build . \
+RUN go build . \
     && ls -l /ollama
 
-FROM docker.io/nvidia/cuda:12.4.1-runtime-ubi9
+FROM docker.io/nvidia/cuda:12.6.3-runtime-ubi9
 
 RUN dnf -y update \
     && dnf install -y --nodocs pciutils \

--- a/Containerfile.build
+++ b/Containerfile.build
@@ -27,7 +27,7 @@ RUN dnf -y update \
     && dnf clean all && rm -rf /var/cache/*
 
 COPY --from=0 /ollama/ollama /usr/local/bin/ollama
-COPY --from=0 /ollama/dist/linux-amd64/lib/ollama /usr/lib/ollama
+#COPY --from=0 /ollama/dist/linux-amd64/lib/ollama /usr/lib/ollama
 
 LABEL maintainer=afred@redhat.com \
       io.k8s.display-name="Ollama AI" \

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@ CONTAINER_ENGINE="${VARIABLE:-podman}"
 IMAGE_REPO="${VARIABLE:-quay.io/redhat-ai-dev/ollama-ubi}"
 
 #OLLAMA_VERSION=$(curl -s "https://api.github.com/repos/ollama/ollama/releases/latest" | jq -r .name)
-OLLAMA_VERSION="v0.4.7"
+OLLAMA_VERSION="v0.5.5"
 
 echo ${OLLAMA_VERSION} > VERSION
 


### PR DESCRIPTION
- Upgrades ollama to v0.5.5 which will pull in support for some new granite 3.1 models
- Need to see if this builds cleanly first