### PR TITLE
Bump ollama-ubi to v0.15.5

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 CONTAINER_ENGINE="${VARIABLE:-podman}"
 IMAGE_REPO="${VARIABLE:-quay.io/redhat-ai-dev/ollama-ubi}"
 
-OLLAMA_VERSION="v0.12.8"
+OLLAMA_VERSION="v0.15.5"
 
 echo ${OLLAMA_VERSION} > VERSION
 


### PR DESCRIPTION
Upgrade to the latest Ollama version - I suspect the Cuda base image will likely need an update too, but waiting to see if there are any CI failures as I'm not able to build this locally.